### PR TITLE
add unix domain socket support

### DIFF
--- a/src/connectors/wire/WireServer.cpp
+++ b/src/connectors/wire/WireServer.cpp
@@ -1,15 +1,12 @@
 #include <cucumber-cpp/internal/connectors/wire/WireServer.hpp>
+#include <cstdio>
 
 namespace cucumber {
 namespace internal {
 
-SocketServer::SocketServer(const ProtocolHandler *protocolHandler) :
-    ios(),
-    acceptor(ios),
-    protocolHandler(protocolHandler) {
-}
-
-void SocketServer::listen(const port_type port) {
+template <>
+template <>
+void SocketServer<boost::asio::ip::tcp>::listen(unsigned short const& port) {
     tcp::endpoint endpoint(tcp::v4(), port);
     acceptor.open(endpoint.protocol());
     acceptor.set_option(tcp::acceptor::reuse_address(true));
@@ -17,17 +14,14 @@ void SocketServer::listen(const port_type port) {
     acceptor.listen(1);
 }
 
-void SocketServer::acceptOnce() {
-    tcp::iostream stream;
-    acceptor.accept(*stream.rdbuf());
-    processStream(stream);
-}
-
-void SocketServer::processStream(tcp::iostream &stream) {
-    std::string request;
-    while (getline(stream, request)) {
-        stream << protocolHandler->handle(request) << std::endl << std::flush;
-    }
+template <>
+template <>
+void SocketServer<boost::asio::local::stream_protocol>::listen(std::string const& path) {
+	std::remove(path.c_str());
+	local::stream_protocol::endpoint endpoint(path);
+    acceptor.open(endpoint.protocol());
+    acceptor.bind(endpoint);
+    acceptor.listen(1);
 }
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,12 +5,13 @@
 
 namespace {
 
-void acceptWireProtocol(int port) {
+template <class Protocol, class Identifier>
+void acceptWireProtocol(Identifier const& port) {
     using namespace ::cucumber::internal;
     CukeEngineImpl cukeEngine;
     JsonSpiritWireMessageCodec wireCodec;
     WireProtocolHandler protocolHandler(&wireCodec, &cukeEngine);
-    SocketServer server(&protocolHandler);
+    SocketServer<Protocol> server(&protocolHandler);
     server.listen(port);
     server.acceptOnce();
 }
@@ -19,13 +20,28 @@ void acceptWireProtocol(int port) {
 
 int main(int argc, char **argv) {
     try {
-        int port = 3902;
+        unsigned short port = 3902;
+		std::string unix_socket;
+
         if (argc > 1) {
+
             std::string firstArg(argv[1]);
-            port = ::cucumber::internal::fromString<int>(firstArg);
+
+			try {
+				port = ::cucumber::internal::fromString<int>(firstArg);
+			} catch (...) {
+				unix_socket = firstArg;
+			}
         }
-        std::clog << "Listening on port " << port << std::endl;
-        acceptWireProtocol(port);
+
+		if (unix_socket.empty()) {
+			std::clog << "Listening on port " << port << std::endl;
+			acceptWireProtocol<boost::asio::ip::tcp>(port);
+		} else {
+			std::clog << "Listening on " << unix_socket << std::endl;
+			acceptWireProtocol<boost::asio::local::stream_protocol>(unix_socket);
+		}
+
     } catch (std::exception &e) {
         std::cerr << e.what() << std::endl;
         exit(1);


### PR DESCRIPTION
Hello, This is so the cucumber wire protocol can use a unix domain socket when the *Steps program is run with a path rather than a port number.

(unix sockets are much better for services on unix machines like linux, OS X, solaris, BSD... really anything that isn't windows. They're substantially faster and don't have firewall issues because they're always local. I have a pull request to the cucumber project that makes this configurable on their end)

Thanks!
